### PR TITLE
[Add]メール確認用Gem パスワード再設定画面　退会画面　退会ページルーティング

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'letter_opener_web'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,14 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.4.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -281,6 +289,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   kaminari (~> 1.1.1)
+  letter_opener_web
   listen (>= 3.0.5, < 3.2)
   paranoia
   puma (~> 3.11)

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,10 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>登録メールアドレス: <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワード再設定を行います。以下のURLより設定を行ってください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワード再設定', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このメールに心当たりが無い場合や、パスワード変更するのをやめる場合は何もする必要はございません。</p>
+<p>上記URLで設定を完了するまで、パスワードは変更されません。</p>
+
+<p>ながのCAKE</p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,27 +1,36 @@
-<h2>Change your password</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
+<div class="container">
 
-  <%= f.input :reset_password_token, as: :hidden %>
-  <%= f.full_error :reset_password_token %>
+  <h2>パスワード再設定</h2>
 
-  <div class="form-inputs">
-    <%= f.input :password,
-                label: "New password",
-                required: true,
-                autofocus: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                label: "Confirm your new password",
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
-  </div>
+  <p>パスワードを再設定します。<br>
+    新しいパスワードを入力してください。
+  </p>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Change my password" %>
-  </div>
-<% end %>
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= f.error_notification %>
 
-<%= render "users/shared/links" %>
+    <%= f.input :reset_password_token, as: :hidden %>
+    <%= f.full_error :reset_password_token %>
+
+    <div class="form-inputs">
+      <%= f.input :password,
+                  label: "新しいパスワード",
+                  required: true,
+                  autofocus: true,
+                  hint: ("#{@minimum_password_length} 文字以上" if @minimum_password_length),
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :password_confirmation,
+                  label: "新しいパスワード再入力",
+                  required: true,
+                  input_html: { autocomplete: "new-password" } %>
+    </div>
+
+    <div class="form-actions">
+      <%= f.button :submit, "パスワード再設定" %>
+    </div>
+  <% end %>
+
+  <%= render "users/shared/links" %>
+
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,18 +1,23 @@
-<h2>Forgot your password?</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= f.error_notification %>
+<div class="container">
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-  </div>
+  <h2>パスワードをお忘れですか？</h2>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Send me reset password instructions" %>
-  </div>
-<% end %>
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= f.error_notification %>
 
-<%= render "users/shared/links" %>
+    <div class="form-inputs">
+      <%= f.input :email,
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" } %>
+    </div>
+
+    <div class="form-actions">
+      <%= f.button :submit, "パスワード再設定メールを送る", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+
+  <%= render "users/shared/links" %>
+
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,9 +1,9 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "新規会員登録", new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/users/withdrawal.html.erb
+++ b/app/views/users/withdrawal.html.erb
@@ -1,2 +1,24 @@
-<h1>Users#withdrawal</h1>
-<p>Find me in app/views/users/withdrawal.html.erb</p>
+
+<div class="container">
+
+	<div class="center-block">
+
+		<h2 class="text-center">本当に退会しますか？</h2>
+
+		<p class="text-center">退会すると、会員登録情報や</p>
+		<p class="text-center">これまでの購入履歴が閲覧できなくなります。</p>
+		<p class="text-center">退会する場合は、「退会する」をクリックしてください</p>
+
+
+			<div class="form-group row justify-content-center">
+				<div>
+					<%= link_to '退会しない', user_path(current_user), class: "btn btn-info", type: "button" %>
+					<%= link_to '退会する', current_user, data: { confirm: "本当に退会しますか？" }, method: :delete, class: "btn btn-danger", type: "button" %>
+				</div>
+			</div>
+			<!-- ボタンを中央揃え出来なかったので、ヘルプお願いしますm(_ _)m -->
+
+		</div>
+
+
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.delivery_method = :letter_opener_web
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,9 @@ Rails.application.routes.draw do
   get 'home/thanks'
   devise_for :users
   devise_for :admins
+  get 'users/withdrawal', to: 'users#withdrawal'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :users,  only: [:edit, :show, :update, :withdrawal] do
+  resources :users,  only: [:edit, :show, :update] do
     resources :orders, only: [:index, :show, :new, :create]
     resources :order_items, only: [:create]
     resources :cart_items
@@ -25,6 +26,10 @@ Rails.application.routes.draw do
     end
   namespace :admin do
     resources :genres
+  end
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 end
 


### PR DESCRIPTION
パスワード再設定メール確認用のGem　「letter_opener_web」の追加

パスワード再設定画面、ユーザー退会画面の追加

退会ページへのルーティングがなかったので、ルーティングを追加